### PR TITLE
Reduce minimum chat height

### DIFF
--- a/src/main/java/dev/thource/runelite/resizablechat/ResizableChatConfig.java
+++ b/src/main/java/dev/thource/runelite/resizablechat/ResizableChatConfig.java
@@ -12,7 +12,7 @@ public interface ResizableChatConfig extends Config {
 
   String CONFIG_GROUP = "resizableChat";
 
-  @Range(min = 142)
+  @Range(min = 28)
   @ConfigItem(
       keyName = "chatHeight",
       name = "Chat height",


### PR DESCRIPTION
Reducing the minimum chat height to 28 px will only show the chat box where you enter text and not the chat history, which is nice when you want to type text but not see the chat log.